### PR TITLE
some modif in swimplot.R

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,9 +1,9 @@
 Package: swimplot
 Title: Tools for Creating Swimmers Plots using 'ggplot2'
 Description: Used for creating swimmers plots with functions to customize the bars, add points, add lines, add text, and add arrows.
-Version: 1.2.0
+Version: 1.2.1
 License: GPL-3
-Author: Jessica Weiss <jessica.weiss@uhnresearch.ca>, Wei Xu<Wei.Xu@uhnresearch.ca>
+Author: Jessica Weiss <jessica.weiss@uhnresearch.ca>, Wei Xu<Wei.Xu@uhnresearch.ca>, Wael Salem Zrafi<zrafiws@gmail.com>
 Maintainer: Jessica Weiss <jessica.weiss@uhnresearch.ca>
 Imports: 
     tidyr,

--- a/R/swimplot.R
+++ b/R/swimplot.R
@@ -166,8 +166,7 @@ swimmer_plot <- function(df,id='id',end='end',start='start',name_fill=NULL,name_
     df$starting_bars_variable[is.na(df$starting_bars_variable)] <- 0
   }
 
-  temp_end <- df[,end] - stats::ave(df[,end], df[,id], FUN=dplyr::lag)
-  df[,end][!is.na(temp_end)] <- temp_end[!is.na(temp_end)]
+
 
 
 


### PR DESCRIPTION
fixing the overlapping time periods (treat differently overlapping and blank time period)
eliminate the  negative NA period 
replace "NA" with "overlapping_time" and "blank_time" in case were name_fill was provided   
more friendly with retrospective data